### PR TITLE
Modify the flag to identify data objects which annotation required

### DIFF
--- a/aws_sagemaker_ground_truth_sample_lambda/pre_human_task_lambda.py
+++ b/aws_sagemaker_ground_truth_sample_lambda/pre_human_task_lambda.py
@@ -43,7 +43,7 @@ def lambda_handler(event, context):
            "taskInput":{
               "taskObject":src_url_http
            },
-           "humanAnnotationRequired":"true"
+           "isHumanAnnotationRequired":"true"
         }
 
 
@@ -70,13 +70,13 @@ def lambda_handler(event, context):
         "taskInput": {
             "taskObject": task_object
         },
-        "humanAnnotationRequired": "true"
+        "isHumanAnnotationRequired": "true"
     }
 
     print(output)
     # If neither source nor source-ref specified, mark the annotation failed
     if task_object is None:
         print(" Failed to pre-process {} !".format(event["labelingJobArn"]))
-        output["humanAnnotationRequired"] = "false"
+        output["isHumanAnnotationRequired"] = "false"
 
     return output

--- a/tests/aws_sagemaker_ground_truth_sample_lambda/pre_human_task_lambda.py
+++ b/tests/aws_sagemaker_ground_truth_sample_lambda/pre_human_task_lambda.py
@@ -43,7 +43,7 @@ def lambda_handler(event, context):
            "taskInput":{
               "taskObject":src_url_http
            },
-           "humanAnnotationRequired":"true"
+           "isHumanAnnotationRequired":"true"
         }
 
 
@@ -70,13 +70,13 @@ def lambda_handler(event, context):
         "taskInput": {
             "taskObject": task_object
         },
-        "humanAnnotationRequired": "true"
+        "isHumanAnnotationRequired": "true"
     }
 
     print(output)
     # If neither source nor source-ref specified, mark the annotation failed
     if task_object is None:
         print(" Failed to pre-process {} !".format(event["labelingJobArn"]))
-        output["humanAnnotationRequired"] = "false"
+        output["isHumanAnnotationRequired"] = "false"
 
     return output

--- a/tests/unit/test_pre_human_task_handler.py
+++ b/tests/unit/test_pre_human_task_handler.py
@@ -41,29 +41,29 @@ def lambda_event_with_null_src_and_null_src_ref():
 
 def test_pre_human_task_lambda_handler_with_src_ref_input(lambda_event_with_src_ref):
     lambda_response = pre_human_task_lambda.lambda_handler(lambda_event_with_src_ref, "")
-    # Expected output {"taskInput": {"taskObject": "s3://gt-try-img/deep/deep3.jpg"}, "humanAnnotationRequired": "true"}
+    # Expected output {"taskInput": {"taskObject": "s3://gt-try-img/deep/deep3.jpg"}, "isHumanAnnotationRequired": "true"}
 
     data = json.loads(lambda_response)
 
     assert data["taskInput"]["taskObject"] == "s3://gt-try-img/deep/deep3.jpg"
-    assert data["humanAnnotationRequired"] == "true"
+    assert data["isHumanAnnotationRequired"] == "true"
 
 
 def test_pre_human_task_lambda_handler_with_src_input(lambda_event_with_src):
     lambda_response = pre_human_task_lambda.lambda_handler(lambda_event_with_src, "")
-    # Expected output {"taskInput": {"taskObject": "some-test-text"}, "humanAnnotationRequired": "true"}
+    # Expected output {"taskInput": {"taskObject": "some-test-text"}, "isHumanAnnotationRequired": "true"}
 
     data = json.loads(lambda_response)
 
     assert data["taskInput"]["taskObject"] == "some-test-text"
-    assert data["humanAnnotationRequired"] == "true"
+    assert data["isHumanAnnotationRequired"] == "true"
 
 
 def test_pre_human_task_lambda_handler_when_src_or_src_ref_input(lambda_event_with_null_src_and_null_src_ref):
     lambda_response = pre_human_task_lambda.lambda_handler(lambda_event_with_null_src_and_null_src_ref, "")
-    # Expected output {"taskInput": {"taskObject": ""}, "humanAnnotationRequired": "false"}
+    # Expected output {"taskInput": {"taskObject": ""}, "isHumanAnnotationRequired": "false"}
 
     data = json.loads(lambda_response)
 
     assert data["taskInput"]["taskObject"] == None
-    assert data["humanAnnotationRequired"] == "false"
+    assert data["isHumanAnnotationRequired"] == "false"


### PR DESCRIPTION
The name of the key to identify a data object which doesn't need annotations by human must be 'isHumanAnnotationRequired'.

reference:
https://docs.aws.amazon.com/sagemaker/latest/dg/sms-custom-templates-step3.html