### PR TITLE
Changed the runtime as per AWS requirements and to avoid deployment errors

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -15,14 +15,14 @@ Resources:
         Properties:
             CodeUri: aws_sagemaker_ground_truth_sample_lambda/
             Handler: pre_human_task_lambda.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.9
 
     GtRecipeAnnotationConsolidationFunction:
         Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
         Properties:
             CodeUri: aws_sagemaker_ground_truth_sample_lambda/
             Handler: annotation_consolidation_lambda.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.9
 
 Outputs:
 


### PR DESCRIPTION
The python3.9 runtime is required now to deploy or edit lambda functions. The instructions in the README will not work without this change, which is very confusing for new users who may not understand why the deployment is failing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
