### PR TITLE
Update Python Environment to 3.9

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -15,14 +15,14 @@ Resources:
         Properties:
             CodeUri: aws_sagemaker_ground_truth_sample_lambda/
             Handler: pre_human_task_lambda.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.9
 
     GtRecipeAnnotationConsolidationFunction:
         Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
         Properties:
             CodeUri: aws_sagemaker_ground_truth_sample_lambda/
             Handler: annotation_consolidation_lambda.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.9
 
 Outputs:
 

--- a/tests/packaged.yaml
+++ b/tests/packaged.yaml
@@ -31,12 +31,12 @@ Resources:
     Properties:
       CodeUri: s3://gt-recipe/211a753f38b4a22533eeb4797fdae938
       Handler: annotation_consolidation_lambda.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
     Type: AWS::Serverless::Function
   GtRecipePreHumanTaskFunction:
     Properties:
       CodeUri: s3://gt-recipe/211a753f38b4a22533eeb4797fdae938
       Handler: pre_human_task_lambda.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/template.yaml
+++ b/tests/template.yaml
@@ -15,14 +15,14 @@ Resources:
         Properties:
             CodeUri: aws_sagemaker_ground_truth_sample_lambda/
             Handler: pre_human_task_lambda.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.9
 
     GtRecipeAnnotationConsolidationFunction:
         Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
         Properties:
             CodeUri: aws_sagemaker_ground_truth_sample_lambda/
             Handler: annotation_consolidation_lambda.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.9
 
 Outputs:
 


### PR DESCRIPTION
*Issue #, if available: 3

*Description of changes:*
Updated Python runtime from 3.6 to 3.9 for Lambda Resources in this recipe. Python 3.6 is no longer supported by AWS Lambda.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
